### PR TITLE
Implement a release() method because the module destructors are not b…

### DIFF
--- a/module/src/server/implementation/objects/TelmateFrameGrabberImpl.cpp
+++ b/module/src/server/implementation/objects/TelmateFrameGrabberImpl.cpp
@@ -23,9 +23,25 @@ TelmateFrameGrabberImpl::TelmateFrameGrabberImpl(
         std::shared_ptr<MediaPipeline> mediaPipeline) :
         OpenCVFilterImpl(config,
         std::dynamic_pointer_cast<MediaPipelineImpl> (mediaPipeline)) {
+
+    GST_DEBUG("TelmateFrameGrabberImpl::"
+                      "TelmateFrameGrabberImpl() "
+                      "called, %s ", this->epName.c_str());
+
 }
+
 TelmateFrameGrabberImpl::~TelmateFrameGrabberImpl() {
+
+
+
 }
+void TelmateFrameGrabberImpl::release() {
+
+    std::shared_ptr<MediaObject> p = TelmateFrameGrabberOpenCVImpl::getSharedPtr();
+    p.reset();
+    return;
+}
+
 
 int TelmateFrameGrabberImpl::getSnapInterval() {
     return TelmateFrameGrabberOpenCVImpl::snapInterval;
@@ -55,10 +71,11 @@ void TelmateFrameGrabberImpl::setWebRtcEpName(const std::string &epName) {
     return;
 }
 
-    MediaObjectImpl *
-TelmateFrameGrabberImplFactory::createObject(
+MediaObjectImpl *
+    TelmateFrameGrabberImplFactory::createObject(
         const boost::property_tree::ptree &config,
         std::shared_ptr<MediaPipeline> mediaPipeline) const {
+
   return new TelmateFrameGrabberImpl(config, mediaPipeline);
 }
 

--- a/module/src/server/implementation/objects/TelmateFrameGrabberImpl.hpp
+++ b/module/src/server/implementation/objects/TelmateFrameGrabberImpl.hpp
@@ -51,6 +51,9 @@ class TelmateFrameGrabberImpl :
 
     virtual void Serialize(JsonSerializer &serializer);
 
+
+    void release();
+
     int getSnapInterval();
     void setSnapInterval(int snapInterval);
     void setOutputFormat(int outputFormat);
@@ -65,6 +68,7 @@ class TelmateFrameGrabberImpl :
     };
 
     static StaticConstructor staticConstructor;
+
 };
 
 }   // namespace telmateframegrabber

--- a/module/src/server/implementation/objects/TelmateFrameGrabberOpenCVImpl.hpp
+++ b/module/src/server/implementation/objects/TelmateFrameGrabberOpenCVImpl.hpp
@@ -43,11 +43,15 @@ class TelmateFrameGrabberOpenCVImpl : public virtual OpenCVProcess {
 
     virtual void process(cv::Mat &mat);
 
+    void release();
+
     boost::atomic<int> framesCounter;
     int snapInterval;
     std::string storagePath;
     std::string epName;
     int outputFormat;     // 0x0=JPEG 0x1=PNG
+
+
 
  protected:
     std::shared_ptr<MediaObject> getSharedPtr() {


### PR DESCRIPTION
…eing called by kurento. We are now resetting the shared_ptr as a workaround for  triggering the module destructor.