### PR TITLE
attempt to sleep in queueHandler before exiting

### DIFF
--- a/module/src/server/implementation/objects/TelmateFrameGrabberOpenCVImpl.cpp
+++ b/module/src/server/implementation/objects/TelmateFrameGrabberOpenCVImpl.cpp
@@ -132,6 +132,8 @@ void TelmateFrameGrabberOpenCVImpl::queueHandler() {
 
         }
 
+        boost::this_thread::sleep_for(boost::chrono::milliseconds(250));
+
         while(!this->frameQueue->empty()) {
 
             this->frameQueue->pop(ptrVf); // blocks


### PR DESCRIPTION
In rare cases, it may be possible to have a QueueHandler thread exit (because a call was started and stopped very quickly) before the thread is detached which may cause a SIGSEGV